### PR TITLE
fix: data race for meals_required

### DIFF
--- a/philo/includes/philo.h
+++ b/philo/includes/philo.h
@@ -6,7 +6,7 @@
 /*   By: cwoon <cwoon@student.42kl.edu.my>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/16 21:44:29 by cwoon             #+#    #+#             */
-/*   Updated: 2024/12/02 21:16:48 by cwoon            ###   ########.fr       */
+/*   Updated: 2025/02/18 20:07:26 by cwoon            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -88,6 +88,7 @@ typedef struct s_table
 	pthread_mutex_t	lock_print;
 	pthread_mutex_t	lock_is_exit;
 	pthread_mutex_t	lock_is_dead;
+	pthread_mutex_t	lock_global;
 	pthread_mutex_t	lock_forks[MAX_PHILO];
 	t_philo			philo[MAX_PHILO];
 }	t_table;

--- a/philo/srcs/initialize.c
+++ b/philo/srcs/initialize.c
@@ -6,7 +6,7 @@
 /*   By: cwoon <cwoon@student.42kl.edu.my>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/21 18:21:35 by cwoon             #+#    #+#             */
-/*   Updated: 2024/12/02 21:27:28 by cwoon            ###   ########.fr       */
+/*   Updated: 2025/02/18 20:07:40 by cwoon            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,6 +64,7 @@ void	initialize_locks(t_table *table)
 	}
 	if (pthread_mutex_init(&table->lock_is_exit, 0) != 0 \
 	|| pthread_mutex_init(&table->lock_print, 0) != 0 \
+	|| pthread_mutex_init(&table->lock_global, 0) != 0 \
 	|| pthread_mutex_init(&table->lock_is_dead, 0) != 0)
 		return (handle_error(table, MUTEX_ERROR));
 }

--- a/philo/srcs/main.c
+++ b/philo/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: cwoon <cwoon@student.42kl.edu.my>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/16 21:44:48 by cwoon             #+#    #+#             */
-/*   Updated: 2024/12/02 21:53:50 by cwoon            ###   ########.fr       */
+/*   Updated: 2025/02/18 20:11:41 by cwoon            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,14 +43,17 @@ void	monitor_death(t_table *table)
 		while (infinite && i < table->total_philos)
 		{
 			usleep(100);
+			pthread_mutex_lock(&table->lock_global);
 			if (table->philo->meals_required == 0 \
-			|| is_exit_simulation(table) \
-			|| is_dead(&table->philo[i]))
-			{
-				infinite = 0;
-				break ;
-			}
-			i++;
+				|| is_exit_simulation(table) \
+				|| is_dead(&table->philo[i]))
+				{
+					infinite = 0;
+					pthread_mutex_unlock(&table->lock_global);
+					break ;
+				}
+				i++;
+			pthread_mutex_unlock(&table->lock_global);
 		}
 	}
 }

--- a/philo/srcs/routine.c
+++ b/philo/srcs/routine.c
@@ -6,7 +6,7 @@
 /*   By: cwoon <cwoon@student.42kl.edu.my>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/26 17:06:56 by cwoon             #+#    #+#             */
-/*   Updated: 2024/12/02 21:57:13 by cwoon            ###   ########.fr       */
+/*   Updated: 2025/02/18 20:25:24 by cwoon            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,9 @@ void	eat_routine(t_philo *philo)
 	philo->last_meal = get_time_in_ms();
 	pthread_mutex_unlock(&philo->lock_eat_routine);
 	waiting(philo->table, philo->table->time_to_eat);
+	pthread_mutex_lock(&philo->table->lock_global);
 	philo->meals_required -= 1;
+	pthread_mutex_unlock(&philo->table->lock_global);
 	pthread_mutex_unlock(&philo->table->lock_forks[philo->fork[1]]);
 	pthread_mutex_unlock(&philo->table->lock_forks[philo->fork[0]]);
 }


### PR DESCRIPTION
meals_required needed a global mutex that can be accessed by both the philo thread and the main thread(parent process)