### PR TITLE
fix: potential deadlock issue

### DIFF
--- a/philo/srcs/routine.c
+++ b/philo/srcs/routine.c
@@ -6,7 +6,7 @@
 /*   By: cwoon <cwoon@student.42kl.edu.my>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/26 17:06:56 by cwoon             #+#    #+#             */
-/*   Updated: 2025/02/18 20:25:24 by cwoon            ###   ########.fr       */
+/*   Updated: 2025/02/18 22:04:16 by cwoon            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,9 +48,14 @@ void	*lonely_philo(t_philo *philo)
 
 void	eat_routine(t_philo *philo)
 {
-	pthread_mutex_lock(&philo->table->lock_forks[philo->fork[0]]);
+	if (philo->fork[0] < philo->fork[1]) {
+		pthread_mutex_lock(&philo->table->lock_forks[philo->fork[0]]);
+		pthread_mutex_lock(&philo->table->lock_forks[philo->fork[1]]);
+	} else {
+		pthread_mutex_lock(&philo->table->lock_forks[philo->fork[1]]);
+		pthread_mutex_lock(&philo->table->lock_forks[philo->fork[0]]);
+	}
 	print_action(philo, GOT_FORK_1);
-	pthread_mutex_lock(&philo->table->lock_forks[philo->fork[1]]);
 	print_action(philo, GOT_FORK_2);
 	print_action(philo, EATING);
 	pthread_mutex_lock(&philo->lock_eat_routine);
@@ -60,8 +65,13 @@ void	eat_routine(t_philo *philo)
 	pthread_mutex_lock(&philo->table->lock_global);
 	philo->meals_required -= 1;
 	pthread_mutex_unlock(&philo->table->lock_global);
-	pthread_mutex_unlock(&philo->table->lock_forks[philo->fork[1]]);
-	pthread_mutex_unlock(&philo->table->lock_forks[philo->fork[0]]);
+	if (philo->fork[0] < philo->fork[1]) {
+		pthread_mutex_unlock(&philo->table->lock_forks[philo->fork[1]]);
+		pthread_mutex_unlock(&philo->table->lock_forks[philo->fork[0]]);
+	} else {
+		pthread_mutex_unlock(&philo->table->lock_forks[philo->fork[0]]);
+		pthread_mutex_unlock(&philo->table->lock_forks[philo->fork[1]]);
+	}
 }
 
 void	sleep_think_routine(t_philo *philo)


### PR DESCRIPTION
due to order of locking the forks:

2 philo context

philo A
fork[0] - Af
fork[1] - Bf

philo B
fork[0] - Bf
fork[1] -Af

if we plainly follow lock fork[0] then fork[1]
A will lock Af
B will lock Bf
then both of them will be waiting for each others fork

if we follow according to which fork should go first (in this context is A)
A will lock Af
B will lock Af (itll wait until Af is free from previous lock only it locks Af)